### PR TITLE
Feat: "Alert 모달 버튼 색상 클래스 처리"

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -12,6 +12,44 @@
         padding: 10px;
         font-size: 14px;
     }
+
+    .warning-title {
+        @apply text-red-600 font-bold text-base
+    }
+
+    .info-title {
+        @apply text-blue-600 font-bold text-base
+    }
+
+    .confirm-title {
+        @apply text-green-600 font-bold text-base
+    }
+
+    .warning-ok-btn {
+        @apply bg-red-600 w-16 p-2 rounded font-bold text-base text-white
+    }
+
+    .warning-cancel-btn {
+        @apply border border-red-600 w-16 p-2 rounded font-bold text-base text-red-600
+    }
+
+    .confirm-ok-btn {
+        @apply bg-green-600 w-16 p-2 rounded font-bold text-base text-white
+    }
+
+    .confirm-cancle-btn {
+        @apply border border-green-600 w-16 p-2 rounded font-bold text-base text-green-600
+    }
+
+    .info-ok-btn {
+        @apply bg-blue-600 w-16 p-2 rounded font-bold text-base text-white
+    }
+
+    .info-cancel-btn {
+        @apply border border-blue-600 w-16 p-2 rounded font-bold text-base text-blue-600
+    }
+
+
 }
 
 @layer base {

--- a/src/components/AlertModalItem.vue
+++ b/src/components/AlertModalItem.vue
@@ -43,21 +43,21 @@ const titleIconSrc = computed(() => {
 })
 
 const textColorMode = computed(() => {
-    if (alertType.value === 'warning') return 'text-red-600 font-bold text-base'
-    else if (alertType.value === 'confirm') return 'text-green-600 font-bold text-base'
-    else return 'text-blue-600 font-bold text-base'
+    if (alertType.value === 'warning') return 'warning-title'
+    else if (alertType.value === 'confirm') return 'confirm-title'
+    else return 'info-title'
 })
 
 const okBtnColorMode = computed(() => {
-    if (alertType.value === 'warning') return 'bg-red-600 w-16 p-2 rounded font-bold text-base text-white'
-    else if (alertType.value === 'confirm') return 'bg-green-600 w-16 p-2 rounded font-bold text-base text-white'
-    else return 'bg-blue-600 w-16 p-2 rounded font-bold text-base text-white'
+    if (alertType.value === 'warning') return 'warning-ok-btn'
+    else if (alertType.value === 'confirm') return 'confirm-ok-btn'
+    else return 'info-ok-btn'
 })
 
 const cancelBtnColorMode = computed(() => {
-    if (alertType.value === 'warning') return 'border border-red-600 w-16 p-2 rounded font-bold text-base text-red-600'
-    else if (alertType.value === 'confirm') return 'border border-green-600 w-16 p-2 rounded font-bold text-base text-green-600'
-    else return 'border border-blue-600 w-16 p-2 rounded font-bold text-base text-blue-600'
+    if (alertType.value === 'warning') return 'warning-cancel-btn'
+    else if (alertType.value === 'confirm') return 'confirm-cancle-btn'
+    else return 'info-cancel-btn '
 })
 
 


### PR DESCRIPTION
기존에 클래스명을 여러 개 리턴하여 처리하던 부분을 @apply로 정리

Resolve: #21
Ref: #18

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/21 -> develop

### 변경 사항
- Alert 모달 타입별(info, confirm, warning) 버튼 색상 apply로 처리
- AlertModalItem.vue 삭제 고려 (toast로 대체?)
